### PR TITLE
Some improvements to the factory

### DIFF
--- a/disk_publisher_test.go
+++ b/disk_publisher_test.go
@@ -10,12 +10,11 @@ import (
 	"github.com/vds/oops"
 )
 
-//Tests that the DiskPublisher can write a oops on the disk correctly.
 func TestDiskPublisherWrite(t *testing.T) {
-	e := errors.New("this is an error")
-	o := oops.Oops{}
-	o.SetError(e, true)
-	o.Id = "oopsId"
+	o := oops.Oops{
+		Id:    "oopsId",
+		Error: errors.New("this is an error").Error(),
+	}
 	tempFolder, err := ioutil.TempDir("/tmp", "oops")
 	if err != nil {
 		t.Error("error creating temporary directory for oopses")
@@ -43,12 +42,11 @@ func TestDiskPublisherWrite(t *testing.T) {
 	}
 }
 
-//Tests that the DiskPublisher can read a oops from the disk correctly.
 func TestDiskPublisherRead(t *testing.T) {
-	e := errors.New("this is an error")
-	o0 := oops.Oops{}
-	o0.SetError(e, true)
-	o0.Id = "oopsId"
+	o0 := oops.Oops{
+		Id:    "oopsId",
+		Error: errors.New("this is an error").Error(),
+	}
 	tempFolder, err := ioutil.TempDir("/tmp", "oops")
 	if err != nil {
 		t.Error("error creating temporary directory for oopses")

--- a/doc.go
+++ b/doc.go
@@ -10,8 +10,8 @@ Example
 
 	err := errors.New("this is an error")
 	tempFolder, err := ioutil.TempDir("/tmp", "oops")
-	p := publishers.DiskPublisher{tempFolder}
-	of := factory.OopsFactory{p}
+	p := oops.DiskPublisher{tempFolder}
+	of := oops.Factory{p}
 	requestData := map[string]string{}
 	id := of.New(err, requestData)
 	// Log that an Oops was recorded, together with the Oops id

--- a/factory.go
+++ b/factory.go
@@ -18,14 +18,14 @@ func _id() (id string) {
 	return fmt.Sprintf("OOPS-%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
 }
 
-// OopsFactory is the component that holds the configuration and that is used to create the oopses.
-type OopsFactory struct {
+// Factory is the component that holds the configuration and that is used to create the oopses.
+type Factory struct {
 	Publisher Publisher
 }
 
 // newOops creates a new oops from an error or a panic and delegate the publisher to persist
 // said oops.
-func (of OopsFactory) newOops(e error, panic bool, requestDetails map[string]string) string {
+func (of Factory) newOops(e error, panic bool, requestDetails map[string]string) string {
 	o := Oops{
 		Id:             _id(),
 		Time:           time.Now(),
@@ -38,12 +38,12 @@ func (of OopsFactory) newOops(e error, panic bool, requestDetails map[string]str
 
 // New creates a new oops from an error and delegates the publisher to persist
 // it.
-func (of OopsFactory) New(e error, requestDetails map[string]string) string {
+func (of Factory) New(e error, requestDetails map[string]string) string {
 	return of.newOops(e, false, requestDetails)
 }
 
 // NewPanic creates a new oops for a panic and delegates the publisher to
 // persist it.
-func (of OopsFactory) NewPanic(requestDetails map[string]string) string {
-	return of.newOops(nil, true, requestDetails)
+func (of Factory) NewPanic(e error, requestDetails map[string]string) string {
+	return of.newOops(e, true, requestDetails)
 }

--- a/factory_test.go
+++ b/factory_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -22,7 +23,12 @@ func TestCreationAndPublicationOfAOops(t *testing.T) {
 	defer os.RemoveAll(tempFolder)
 	p := oops.DiskPublisher{tempFolder}
 	of := oops.Factory{p}
-	id := of.New(e, map[string]string{})
+	reqDetails := map[string]string{"foo": "bar"}
+	stack := "stack"
+	id, err := of.New(e, oops.SetStack(stack), oops.SetRequestDetails(reqDetails))
+	if err != nil {
+		t.Fatalf("Failed to create new OOPS: %v", err)
+	}
 	matched, err := regexp.MatchString(`^OOPS-\S{8}-\S{4}-\S{4}-\S{4}-\S{12}$`, id)
 	if err != nil {
 		t.Error("error creating regexp")
@@ -34,7 +40,10 @@ func TestCreationAndPublicationOfAOops(t *testing.T) {
 	if o.Error != errorString {
 		t.Error("error matching error string")
 	}
-	if o.Stack == "" {
-		t.Error("error, empty stack")
+	if o.Stack != stack {
+		t.Errorf("Unexpected stack; got %s, want %s", o.Stack, stack)
+	}
+	if !reflect.DeepEqual(o.RequestDetails, reqDetails) {
+		t.Errorf("Unexpected request details; got %s, want %s", o.RequestDetails, reqDetails)
 	}
 }

--- a/factory_test.go
+++ b/factory_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/vds/oops"
 )
 
-// Tests the whole workflow, the creation of the Publisher, the OopsFactory, the creation of a
+// Tests the whole workflow, the creation of the Publisher, the Factory, the creation of a
 // oops and the recording of information from an error from a panic.
 func TestCreationAndPublicationOfAOops(t *testing.T) {
 	errorString := "this is an error"
@@ -21,7 +21,7 @@ func TestCreationAndPublicationOfAOops(t *testing.T) {
 	}
 	defer os.RemoveAll(tempFolder)
 	p := oops.DiskPublisher{tempFolder}
-	of := oops.OopsFactory{p}
+	of := oops.Factory{p}
 	id := of.New(e, map[string]string{})
 	matched, err := regexp.MatchString(`^OOPS-\S{8}-\S{4}-\S{4}-\S{4}-\S{12}$`, id)
 	if err != nil {

--- a/in_memory_publisher_test.go
+++ b/in_memory_publisher_test.go
@@ -11,10 +11,10 @@ import (
 
 //Tests that the InMemoryOopsStorage can store an oops correctly.
 func TestInMemoryPublisherWrite(t *testing.T) {
-	e := errors.New("this is an error")
-	o := oops.Oops{}
-	o.SetError(e, true)
-	o.Id = "oopsId"
+	o := oops.Oops{
+		Id:    "oopsId",
+		Error: errors.New("this is an error").Error(),
+	}
 	s := make(oops.InMemoryOopsStorage)
 	p := oops.InMemoryPublisher{s, sync.Mutex{}}
 	p.Write(o)
@@ -25,10 +25,10 @@ func TestInMemoryPublisherWrite(t *testing.T) {
 
 //Tests that the InMemoryOopsStorage can read an oops correctly.
 func TestInMemoryPublisherRead(t *testing.T) {
-	e := errors.New("this is an error")
-	o := oops.Oops{}
-	o.SetError(e, true)
-	o.Id = "oopsId"
+	o := oops.Oops{
+		Id:    "oopsId",
+		Error: errors.New("this is an error").Error(),
+	}
 	s := make(oops.InMemoryOopsStorage)
 	p := oops.InMemoryPublisher{s, sync.Mutex{}}
 	p.Write(o)

--- a/oops.go
+++ b/oops.go
@@ -3,8 +3,6 @@ package oops
 import (
 	"bytes"
 	"encoding/gob"
-	"reflect"
-	"runtime"
 	"time"
 )
 
@@ -17,28 +15,6 @@ type Oops struct {
 	Error          string
 	ErrorType      string
 	Panic          bool
-}
-
-// SetError records the information about the error or the panic.
-func (o *Oops) SetError(e error, panic bool) {
-	o.Panic = panic
-	o.Error = e.Error()
-	stack := make([]byte, 1<<20)
-	for i := 0; ; i++ {
-		n := runtime.Stack(stack, true)
-		if n < len(stack) {
-			stack = stack[:n]
-			break
-		}
-		if len(stack) >= 64<<20 {
-			// Filled 64 MB - stop there.
-			break
-		}
-		stack = make([]byte, 2*len(stack))
-	}
-
-	o.Stack = string(stack)
-	o.ErrorType = reflect.TypeOf(e).String()
 }
 
 // Marshal returns a gob encoding of the oops.

--- a/oops_test.go
+++ b/oops_test.go
@@ -1,8 +1,6 @@
 package oops_test
 
 import (
-	"bytes"
-	"encoding/gob"
 	"errors"
 	"reflect"
 	"testing"
@@ -10,71 +8,25 @@ import (
 	"github.com/vds/oops"
 )
 
-// Tests the creation of a oops and the recording of information from an error from a panic.
-func TestOopsPutError(t *testing.T) {
-
-	errorString := "this is an error"
-	err := errors.New(errorString)
-	o := oops.Oops{}
-	o.SetError(err, true)
-
-	if o.Stack == "" {
-		t.Error("stack is empty")
-	}
-
-	if o.Error != errorString {
-		t.Errorf("wrong error: %v", o.Error)
-	}
-
-	if o.ErrorType == "" {
-		t.Error("ErrorType is empty")
-	}
-
-	if o.Panic == false {
-		t.Error("ErrorType is empty")
-	}
-}
-
-// Tests the binary marshalling of a oops.
-func TestOopsMarshal(t *testing.T) {
-
+func TestOopsMarshalAndUnmarshal(t *testing.T) {
 	err := errors.New("this is an error")
-	o0 := oops.Oops{}
-	o0.SetError(err, true)
-
-	encoded_oops, err := o0.Marshal()
-	if err != nil {
-		t.Error(err)
+	o0 := oops.Oops{
+		Error:          err.Error(),
+		Panic:          true,
+		Stack:          "stack",
+		RequestDetails: map[string]string{"foo": "bar"},
 	}
-	dec := gob.NewDecoder(bytes.NewReader(encoded_oops))
-	var o1 oops.Oops
-	err = dec.Decode(&o1)
+
+	encoded, err := o0.Marshal()
 	if err != nil {
-		t.Errorf("failed to decode: %s", err)
-	}
-	if !reflect.DeepEqual(o0, o1) {
-		t.Errorf("decoding does not match.")
-	}
-}
-
-// Tests the binary unmarshalling of a oops.
-func TestOopsUnmarshal(t *testing.T) {
-
-	err := errors.New("this is an error")
-	o0 := oops.Oops{}
-	o0.SetError(err, true)
-
-	encoded_oops, err := o0.Marshal()
-	if err != nil {
-		t.Error(err)
+		t.Fatalf("failed to marshal: %s", err)
 	}
 	var o1 oops.Oops
-	err = o1.Unmarshal(encoded_oops)
+	err = o1.Unmarshal(encoded)
 	if err != nil {
-		t.Errorf("failed to decode: %s", err)
+		t.Fatalf("failed to unmarshal: %s", err)
 	}
-
 	if !reflect.DeepEqual(o0, o1) {
-		t.Errorf("decoding does not match")
+		t.Errorf("unmarshalled OOPS does not match original one.")
 	}
 }


### PR DESCRIPTION
This will allow users to set a custom stack trace, like the one we now store in our errors.

It also changes the signature of Factory.New() to maybe return the error from Publisher.Write()
